### PR TITLE
Feature/IN-123: Hide Deleted Posts

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -339,7 +339,9 @@ def view_post(post_id):
     :param post_id: ID of the Post object being viewed
     :return: HTML template to view a single post
     """
-    post = Posts.query.filter_by(id=post_id).first()
+    post = Posts.query.filter_by(id=post_id,deleted=False).first()
+    if not post:
+        return render_template('404.html'), 404
     post_timestamp = post.date_created.replace(tzinfo=pytz.utc)
     post_timestamp = post_timestamp.astimezone(pytz.timezone("America/New_York"))
     author = Users.query.filter_by(id=post.author).first()


### PR DESCRIPTION
If a post is deleted it is hidden on the front end of the site but can still be accessed by going to the URL manually.