### PR TITLE
IT Support Page Updates

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -49,7 +49,7 @@
                     {% else %}
                         <li><a class="login-button" href="{{ url_for('auth.login') }}">Login</a></li>
                     {% endif %}
-                {% endif %}}
+                {% endif %}
             </ul>
         </div>
     </nav>

--- a/app/templates/faq.html
+++ b/app/templates/faq.html
@@ -38,7 +38,7 @@
                 <li class="common-question-link"><a href="#common-question-answer-8" class="common-question-anchor">Should I reboot my computer?</a></li>
                 <li class="common-question-link"><a href="#common-question-answer-9" class="common-question-anchor">I'm stumped and nothing is working.</a></li>
                 <li class="common-question-link"><a href="#common-question-answer-10" class="common-question-anchor">How do I access archived emails in Enterprise Vault?</a></li>
-                <li class="common-question-link"><a href="#common-question-answer-11" class="common-question-anchor">How do I forward Phishing emails to NYC3 (phish@cyber.nyc.gov)?</a></li>
+                <li class="common-question-link"><a href="#common-question-answer-11" class="common-question-anchor">How do I forward Phishing emails to NYC3 (phish@oti.nyc.gov)?</a></li>
             </ul>
         </div>
         <br>
@@ -166,18 +166,18 @@
             <h1 class="common-question-answer-header">I'm stumped and nothing is working.</h1>
             <p class="common-question-answer-text">Contact:</p>
             <ol class="common-question-answer-text" type="1">
-                <li>DoITT Helpdesk - (718) 403-8888, email - <a href="mailto:nychelp@doitt.nyc.gov">nychelp@doitt.nyc.gov</a></li>
+                <li>OTI Helpdesk - (718) 403-8888, email - <a href="mailto:nychelp@oti.nyc.gov">nychelp@oti.nyc.gov</a></li>
                 <li>IT Support - email - <a href="mailto:itsupport@records.nyc.gov">itsupport@records.nyc.gov</a></li>
             </ol>
         </div>
         <div class="common-question-answer" id="common-question-answer-10">
             <h1 class="common-question-answer-header">How do I access archived emails in Enterprise Vault?</h1>
-            <p class="common-question-answer-text">DoITT has provided the following information regarding accessing
+            <p class="common-question-answer-text">OTI has provided the following information regarding accessing
                 Enterprise Vault and archiving in Office 365:</p>
             <p class="common-question-answer-text">Background: Before the migration to Office 365, the archival platform
-                for emails has been the Enterprise Vault (EV), an on-premises solution hosted at DoITT. After DoITT
+                for emails has been the Enterprise Vault (EV), an on-premises solution hosted at OTI. After OTI
                 migrated all Mailboxes to the cloud (Office 365) then the archiving platform also moved to the cloud.
-                DoITT is working on a project to migrate the legacy data from on-premises Enterprise Vault to Office
+                OTI is working on a project to migrate the legacy data from on-premises Enterprise Vault to Office
                 365. We do not have a date as to when that project will be completed. However, the following information
                 will help you regarding the archival process.</p>
             <p class="common-question-answer-text">How do I access archival items through Enterprise Vault?</p>
@@ -204,13 +204,13 @@
         </div>
         <div class="common-question-answer" id="common-question-answer-11">
             <h1 class="common-question-answer-header">How do I forward Phishing emails to NYC3
-                (phish@cyber.nyc.gov)?</h1>
+                (phish@oti.nyc.gov)?</h1>
             <ol class="common-question-answer-text" type="1">
                 <li>With the suspected phishing email highlighted or opened, hit CTRL-ALT-F. (this will forward the
                     email, with required tracking information (headers), as an attachment, to the NYC Cyber Command
                     Security Operations Center for analysis.)
                 </li>
-                <li>Enter <a href="mailto:phish@cyber.nyc.gov">phish@cyber.nyc.gov</a> as the recipient and click send.
+                <li>Enter <a href="mailto:phish@oti.nyc.gov">phish@oti.nyc.gov</a> as the recipient and click send.
                 </li>
                 <li>Delete the suspicious email from your mailbox without clicking on any hyperlinks or attachments and
                     delete it from the Deleted Items folder.

--- a/app/templates/it_support.html
+++ b/app/templates/it_support.html
@@ -48,7 +48,7 @@
                                     class="glyphicon glyphicon-globe it-support-glyphicon"></span></div>
                             <div class="col-sm-8 doris-help-desk-text">
                                 <p>Phone: (718) 403-8888</p>
-                                <p>Email: <a href="mailto:nychelp@doitt.nyc.gov">nychelp@doitt.nyc.gov</a></p>
+                                <p>Email: <a href="mailto:nychelp@oti.nyc.gov">nychelp@oti.nyc.gov</a></p>
                             </div>
                         </div>
                     </div>
@@ -56,18 +56,20 @@
                 <div class="col-sm-4">
                     <div class="it-support-option-boxes col-sm-12">
                         <div class="row">
-                            <h4 class="it-support-title">TRAINING</h4>
-                            <div class="col-sm-4 training-icon"><span
+                            <h4 class="it-support-title" style="padding-bottom: 15px;">TRAINING</h4>
+                            <div class="col-sm-4 training-icon" style="padding-top: 15px;"><span
                                     class="glyphicon glyphicon-blackboard it-support-glyphicon"></span></div>
                             <div class="col-sm-8 training-text">
                                 <p><a href="https://support.office.com/en-us/office-training-center" rel="noopener"
                                       target="_blank">MS Office Training</a></p>
                                 <p><a href="https://support.microsoft.com/en-us/office/microsoft-teams-video-training-4f108e54-240b-4351-8084-b1089f0d21d7" rel="noopener"
                                       target="_blank">MS Teams Training</a></p>
-                                <p>
-                                    <a href="http://cityshare.nycnet/portal/site/cityshare/menuitem.c523e8a3e0abc9d4e6fd1e10aca088a0/"
+                                <p><a href="https://cityshare.nycnet/content/cityshare/pages/cyber-command/cyber-command-policies"
                                        rel="noopener"
-                                       target="_blank">Password Security and Social Engineering</a></p>
+                                       target="_blank">Cyber Command Policies</a></p>
+                                <p><a href="https://cityshare.nycnet/content/cityshare/pages/information-security/user-awareness"
+                                       rel="noopener"
+                                       target="_blank">User Awareness</a></p>
                             </div>
                         </div>
                     </div>
@@ -85,7 +87,7 @@
                         <p>
                             <a href="https://www.nyc.gov/csdportal" rel="noopener" target="_blank">Citywide Service
                                 Desk</a> is a self-service portal to search knowledge bases, get something fixed, and
-                            request something new from DoITT resources.
+                            request something new from OTI resources.
                         </p>
                     </div>
                 </div>
@@ -112,9 +114,9 @@
                     <div class="it-support-option-boxes col-sm-12">
                         <div class="row">
                             <h4 class="it-support-title">RESOURCES</h4>
-                            <div class="col-sm-4 training-icon"><span
+                            <div class="col-sm-4 resources-icon"><span
                                     class="glyphicon glyphicon-blackboard it-support-glyphicon"></span></div>
-                            <div class="col-sm-8 training-text">
+                            <div class="col-sm-8 resources-text">
                                 <p><a href="{{ url_for('static', filename='files/accessing_doris_public_wifi.pdf') }}">DORIS
                                     Public Wi-Fi</a></p>
                                 <p>
@@ -194,7 +196,7 @@
                                     class="glyphicon glyphicon-question-sign it-support-glyphicon"></span></div>
                             <div class="col-sm-8 doris-help-desk-text">
                                 <p>Phone: (718) 403-6761</p>
-                                <p>Email: <a href="mailto:soc@cyber.nyc.gov">soc@cyber.nyc.gov</a></p>
+                                <p>Email: <a href="mailto:soc@oti.nyc.gov">soc@oti.nyc.gov</a></p>
                             </div>
                         </div>
                     </div>
@@ -215,9 +217,8 @@
                 </div>
                 <div class="col-sm-4">
                     <div class="it-support-text">
-                        <p>Contact the <a href="https://www1.nyc.gov/site/cyber/index.page" rel="noopener"
-                                          target="_blank">NYC Security Operations Center</a> for information about cyber
-                            security.</p>
+                        <p>Contact the <a href="https://www1.nyc.gov/content/oti/pages/" rel="noopener"
+                                          target="_blank">NYC Security Operations Center</a> for information about cybersecurity.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This PR updates the IT Support pages with the following changes:
* Change the email address for Citywide Service Desk to nychelp@oti.nyc.gov
* Change “Contact the NYC Security Operations Center for information about cyber security” link to https://www1.nyc.gov/content/oti/pages/
* Change NYC Security Operations Center email address to soc@oti.nyc.gov
* Under Training remove Password Security and Social Engineering and replace with Cyber Command Policies https://cityshare.nycnet/content/cityshare/pages/cyber-command/cyber-command-policies
* Under Training add Use Awareness https://cityshare.nycnet/content/cityshare/pages/information-security/user-awareness
* Under FAQs change the phishing email to phish@oti.nyc.gov
* Under FAQs change any reference to DoITT to OTI including in email addresses